### PR TITLE
Function for extracting values of repeating fields

### DIFF
--- a/src/main/scala/com/databricks/labs/smolder/functions.scala
+++ b/src/main/scala/com/databricks/labs/smolder/functions.scala
@@ -54,6 +54,17 @@ object functions {
   }
 
   /**
+   * Extracts the value at a specific index in a repeating field
+   * 
+   * @param col A column containing the repeated field from a message segment
+   * @param repIndex The index of repeated field value that must be extracted
+   * @return Yields a new column containing the field of a message segment.
+   */
+  def repeating_field(col: Column, repIndex: Int): Column = {
+    split(col, "~").getItem(repIndex)
+  }
+  
+  /**
    * Parses a "^" delimited subfield from a selected segment field.
    * 
    * @param col The segment field to parse.


### PR DESCRIPTION
## What changes are proposed in this pull request?
Some HL7 segment fields contain more than one value. These are called repeating fields and each value is separated by a ~. For example, PID.3 which contains a list of patient identifiers may have a value like this (fake data):

```
1234567890^^^HOSPITALONE^MRN~4646464646^^^HOSPITALTWO^MRN~9431675613^^^HOSPITALTHRE^MRN
```

The new function `repeating_fields()` allows extracting exactly one of these values.

## How is this patch tested?
- [ ] Unit tests
- [ ] Integration tests
- [X] Manual tests

Function was tested with actual HL7 data.
