### PR TITLE
Adding ability to interface with pyspark through sql ctxt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.class
 *.log
 *target*
+.idea
+.bsp

--- a/README.md
+++ b/README.md
@@ -100,6 +100,21 @@ parsedDf: org.apache.spark.sql.DataFrame = [message: struct<message: string, seg
 
 This yields the same schema as our `hl7` data source.
 
+## Integration with Pyspark
+In order run Scala code with pyspark we must compile the smolder jar and pass it to our cluster. From there, we can do the following:
+```
+# Python
+from pyspark.sql.column import Column
+df = <some pyspark dataframe>
+jvm = sc._jvm
+ssqlContext = sqlContext._ssql_ctx
+jdf = df._jdf
+
+# Access the functions class 
+f = jvm.com.databricks.labs.smolder.functions(ssqlContext, jdf)
+result = df.select(Column(f.parse_hl7_message(jdf.col("value"))).alias("message"))
+```
+
 ## Extracting fields from an HL7 message segment
 
 While Smolder provides an easy-to-use schema for HL7 messages, we also provide

--- a/src/main/scala/com/databricks/labs/smolder/functions.scala
+++ b/src/main/scala/com/databricks/labs/smolder/functions.scala
@@ -18,34 +18,38 @@ package com.databricks.labs.smolder
 import com.databricks.labs.smolder.sql._
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{DataFrame, Row, SQLContext, SparkSession}
 
-object functions {
+
+class functions(sqlContext: SQLContext, df: DataFrame) {
+  import sqlContext.implicits._
+  import org.apache.spark.sql.functions._
 
   /**
-    * Parses a textual, pipe-delimited HL7v2 message.
-    * 
-    * @param message Column containing HL7v2 message text to parse.
-    * @return New column containing parsed HL7 message structure.
-    */
+   * Parses a textual, pipe-delimited HL7v2 message.
+   *
+   * @param message Column containing HL7v2 message text to parse.
+   * @return New column containing parsed HL7 message structure.
+   */
   def parse_hl7_message(message: Column): Column = {
     new Column(new ParseHL7Message(message.expr))
   }
 
   /**
    * Extracts a field from a message segment.
-   * 
+   *
    * @param segment The ID of the segment to extract.
    * @param field The index of the field to extract.
    * @param segmentColumn The name of the column containing message segments.
    *   Defaults to "segments".
    * @return Yields a new column containing the field of a message segment.
-   * 
+   *
    * @note If there are multiple segments with the same ID, this function will
    *   select the field from one of the segments. Order is undefined.
    */
   def segment_field(segment: String,
-    field: Int,
-    segmentColumn: Column = col("segments")): Column = {
+                    field: Int,
+                    segmentColumn: Column = col("segments")): Column = {
 
     filter(segmentColumn, s => s("id") === lit(segment))
       .getItem(0)
@@ -55,7 +59,7 @@ object functions {
 
   /**
    * Parses a "^" delimited subfield from a selected segment field.
-   * 
+   *
    * @param col The segment field to parse.
    * @param subfield The index of the subfield to return.
    * @return Returns the value at this location in the subfield.


### PR DESCRIPTION
## What changes are proposed in this pull request?
- ability to interface with pyspark
- functions converted to class that can handle SQLContext & DataFrame (perhaps there's a cleaner approach here as it changes functionality of calling parse_hl7_message in a standalone way)
- tests for functions updated 

## How is this patch tested?
- Unit tests (specifically for functions)