### PR TITLE
Dev upgrade spark3.2.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -103,14 +103,14 @@ lazy val testCoreDependencies = Seq(
 )
 
 lazy val coreDependencies = (providedSparkDependencies ++ testCoreDependencies ++ Seq(
-  "log4j" % "log4j" % "1.2.17",
+//  "log4j" % "log4j" % "1.2.17",
   "org.slf4j" % "slf4j-api" % "1.7.25",
   "org.slf4j" % "slf4j-log4j12" % "1.7.25",
   "org.jdbi" % "jdbi" % "2.63.1",
   // Fix versions of libraries that are depended on multiple times
-  "org.apache.hadoop" % "hadoop-client" % "2.7.3",
-  "io.netty" % "netty" % "3.9.9.Final",
-  "io.netty" % "netty-all" % "4.1.17.Final",
+  "org.apache.hadoop" % "hadoop-client" % "3.3.1",
+//  "io.netty" % "netty" % "3.9.9.Final",
+//  "io.netty" % "netty-all" % "4.1.17.Final",
   "org.yaml" % "snakeyaml" % "1.16"
 )).map(_.exclude("com.google.code.findbugs", "jsr305"))
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ import sbt.nio.Keys._
 lazy val scala212 = "2.12.8"
 lazy val scala211 = "2.11.12"
 
-lazy val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.0.1")
+lazy val sparkVersion = sys.env.getOrElse("SPARK_VERSION", "3.2.1")
 
 def majorMinorVersion(version: String): String = {
   StringUtils.ordinalIndexOf(version, ".", 2) match {

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,7 @@ Compile / compileOrder := CompileOrder.JavaThenScala
 // Spark session used by many tasks cannot be used concurrently.
 val testConcurrency = 1
 Test / fork := true
-concurrentRestrictions in Global := Seq(
+Global / concurrentRestrictions := Seq(
   Tags.limit(Tags.ForkedTestGroup, testConcurrency)
 )
 
@@ -60,14 +60,14 @@ def groupByHash(tests: Seq[TestDefinition]): Seq[Tests.Group] = {
 lazy val commonSettings = Seq(
   //mainScalastyle := scalastyle.in(Compile).toTask("").value,
   //testScalastyle := scalastyle.in(Test).toTask("").value,
-  testGrouping in Test := groupByHash((definedTests in Test).value),
+  Test / testGrouping := groupByHash((Test / definedTests).value),
   //test in Test := ((test in Test) dependsOn mainScalastyle).value,
   //test in Test := ((test in Test) dependsOn testScalastyle).value,
   //test in Test := ((test in Test) dependsOn scalafmtCheckAll).value,
   //test in Test := ((test in Test) dependsOn (headerCheck in Compile)).value,
   //test in Test := ((test in Test) dependsOn (headerCheck in Test)).value,
-  test in assembly := {},
-  assemblyMergeStrategy in assembly := {
+  assembly / test := {},
+  assembly / assemblyMergeStrategy := {
     // Assembly jar is not executable
     case p if p.toLowerCase.contains("manifest.mf") =>
       MergeStrategy.discard
@@ -132,7 +132,7 @@ lazy val core = (project in file("."))
     publish / skip := false,
     // Adds the Git hash to the MANIFEST file. We set it here instead of relying on sbt-release to
     // do so.
-    packageOptions in (Compile, packageBin) +=
+    Compile / packageBin / packageOptions +=
     Package.ManifestAttributes("Git-Release-Hash" -> currentGitHash(baseDirectory.value)),
     bintrayRepository := "smolder",
     libraryDependencies ++= coreDependencies :+ scalaLoggingDependency.value,
@@ -189,10 +189,9 @@ ThisBuild / stableVersion := IO
 lazy val stagedRelease = (project in file("src/test"))
   .settings(
     commonSettings,
-    resourceDirectory in Test := baseDirectory.value / "resources",
-    scalaSource in Test := baseDirectory.value / "scala",
-    unmanagedSourceDirectories in Test += baseDirectory.value / "shim" / majorMinorVersion(
-      sparkVersion),
+    Test / resourceDirectory := baseDirectory.value / "resources",
+    Test / scalaSource := baseDirectory.value / "scala",
+    Test / unmanagedSourceDirectories += baseDirectory.value / "shim" / majorMinorVersion(sparkVersion),
     libraryDependencies ++= testSparkDependencies ++ testCoreDependencies :+
     "com.databricks.labs" %% "smolder" % stableVersion.value % "test",
     resolvers := Seq("bintray-staging" at "https://dl.bintray.com/com.databricks.labs/smolder"),

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.0
+sbt.version=1.7.1

--- a/src/main/scala/com/databricks/labs/smolder/sql/ParseHL7Message.scala
+++ b/src/main/scala/com/databricks/labs/smolder/sql/ParseHL7Message.scala
@@ -26,7 +26,7 @@ private[smolder] case class ParseHL7Message(child: Expression)
 
   override def dataType: DataType = Message.schema
   override def nullSafeEval(input: Any): Any = Message(input.asInstanceOf[UTF8String]).toInternalRow()
-
+  override protected def withNewChildInternal(newChild: Expression): Expression = copy(child = newChild)
   override def doGenCode(ctx: CodegenContext, ev: ExprCode): ExprCode = {
     nullSafeCodeGen(
       ctx,

--- a/src/test/scala/com/databricks/labs/smolder/SmolderBaseTest.scala
+++ b/src/test/scala/com/databricks/labs/smolder/SmolderBaseTest.scala
@@ -26,7 +26,8 @@ abstract class SmolderBaseTest
 
   protected implicit def spark: SparkSession = {
     val session = SparkSession.builder()
-      .master("local[2]")
+      .master("local[2]") 
+      .config("spark.driver.bindAddress","127.0.0.1") //Explicitly state this for Spark3.2.1
       .getOrCreate()
 
     SparkSession.setActiveSession(session)


### PR DESCRIPTION
## What changes are proposed in this pull request?
Upgrading SBT version to be compatible with JDK 18+ 
Upgrading to Spark3.2.1 version and overriding Unary Trait definition
Upgrading sbt build syntax

## How is this patch tested?
- [x] Unit tests
- [ ] Integration tests
- [x] Manual tests

Unit tests all passed in sbt. Attaching screenshot of manual tests in a Spark 3.2.1. cluster

![image](https://user-images.githubusercontent.com/1775604/199057807-d43f2fbd-0361-47b4-9167-148efb073d7c.png)
